### PR TITLE
[MLIRPythonBindings]adapted the inferredAlignment parameter

### DIFF
--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -1527,7 +1527,7 @@ public:
     if (alignment)
       inferredAlignment = *alignment;
     else
-      inferredAlignment = view->stride_ptr()[view->ndim() - 1];
+      inferredAlignment = static_cast<size_t>(view->stride(view->ndim() - 1) * view->itemsize());
 
     // The userData is a nb::ndarray<nb::any_contig>* that the deleter owns.
     auto deleter = [](void *userData, const void *data, size_t size,

--- a/mlir/test/python/ir/array_attributes.py
+++ b/mlir/test/python/ir/array_attributes.py
@@ -646,7 +646,7 @@ def testGetDenseResourceElementsAttrNdarrayI32():
             module = Module.parse("module {}")
             module.operation.attributes["test.resource"] = resource
             # CHECK: test.resource = dense_resource<from_py> : tensor<2x3xi32>
-            # CHECK: from_py: "0x01000000010000000200000003000000040000000500000006000000"
+            # CHECK: from_py: "0x04000000010000000200000003000000040000000500000006000000"
             print(module)
 
             # Verifies type casting.
@@ -693,7 +693,7 @@ def testGetDenseResourceElementsAttrNdarrayF32():
             module = Module.parse("module {}")
             module.operation.attributes["test.resource"] = resource
             # CHECK: test.resource = dense_resource<from_py> : tensor<2x3xf32>
-            # CHECK: from_py: "0x010000000000803F0000004000004040000080400000A0400000C040"
+            # CHECK: from_py: "0x040000000000803F0000004000004040000080400000A0400000C040"
             print(module)
 
             # Verifies type casting.


### PR DESCRIPTION
Now the inferedAlignment variable is in bytes and not elements anymore.
This is also the case in getFromBuffer().