### PR TITLE
[Linalg][Canonicalization] Add Tensor -> Scalar Pattern

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -52,6 +52,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
+#include <cstdint>
 #include <optional>
 
 using namespace mlir;
@@ -1338,11 +1339,97 @@ struct EraseIdentityLinalgOp : public OpRewritePattern<OpTy> {
   }
 };
 
+struct ScalarizeSingleElementConstants : public OpRewritePattern<GenericOp> {
+  using OpRewritePattern<GenericOp>::OpRewritePattern;
+
+  static bool isScalarOperand(Value operand) {
+    return isa<OpResult>(operand) &&
+           isa<arith::ConstantOp>(operand.getDefiningOp()) &&
+           isa<RankedTensorType>(operand.getType()) &&
+           (cast<RankedTensorType>(operand.getType()).getNumElements() == 1);
+  }
+
+  static arith::ConstantOp
+  createScalarValueFromRankedType(arith::ConstantOp constant,
+                                  PatternRewriter &rewriter) {
+    auto denseAttr = dyn_cast<DenseElementsAttr>(constant.getValueAttr());
+    arith::ConstantOp splatConstantOp(nullptr);
+    if (denseAttr && denseAttr.isSplat()) {
+      splatConstantOp =
+          llvm::TypeSwitch<Attribute, arith::ConstantOp>(
+              denseAttr.getSplatValue<Attribute>())
+              .Case([&](IntegerAttr attr) {
+                return rewriter.create<arith::ConstantOp>(constant.getLoc(),
+                                                          attr);
+              })
+              .Case([&](FloatAttr attr) {
+                return rewriter.create<arith::ConstantOp>(constant.getLoc(),
+                                                          attr);
+              })
+              .Default([](Attribute /*attr*/) -> arith::ConstantOp {
+                return nullptr;
+              });
+    }
+    return splatConstantOp;
+  }
+
+  LogicalResult matchAndRewrite(GenericOp linalgOp,
+                                PatternRewriter &rewriter) const override {
+    // Iterate over the operands and see if there are any ranked constants with
+    // size one that can simply be converted to a "rankless" scalar.
+    llvm::MapVector<int64_t, arith::ConstantOp> operandsToChange;
+    for (auto [idx, operand] : llvm::enumerate(linalgOp.getInputs())) {
+      if (!isScalarOperand(operand)) {
+        continue;
+      }
+      auto constant = cast<arith::ConstantOp>(operand.getDefiningOp());
+      auto splatConstantOp =
+          createScalarValueFromRankedType(constant, rewriter);
+      if (!splatConstantOp) {
+        std::ignore = rewriter.notifyMatchFailure(
+            operand.getLoc(), "cannot extract splat value from constant");
+        continue;
+      }
+      operandsToChange[idx] = splatConstantOp;
+    }
+
+    if (operandsToChange.empty()) {
+      return rewriter.notifyMatchFailure(
+          linalgOp, "does not have scalar operands in RankedTensorTypes");
+    }
+
+    // Update the operands and indexing maps with the new constants. The
+    // indexing maps will be changed to be rankless instead of constant
+    // expression.
+    SmallVector<Value> newOperands(linalgOp.getInputs());
+    SmallVector<AffineMap> newIndexingMaps(linalgOp.getIndexingMapsArray());
+    for (auto [idx, newConstantOp] : operandsToChange) {
+      AffineMap indexing = newIndexingMaps[idx];
+      newIndexingMaps[idx] =
+          AffineMap::get(indexing.getNumDims(), /*symbolCount*/ 0,
+                         SmallVector<AffineExpr>(), rewriter.getContext());
+      newOperands[idx] = newConstantOp;
+    }
+
+    // Create the modified generic and replace.
+    GenericOp replacementOp = rewriter.create<GenericOp>(
+        linalgOp.getLoc(), linalgOp.getResultTensors().getTypes(),
+        ValueRange(newOperands), SmallVector<Value>(linalgOp.getOutputs()),
+        newIndexingMaps, linalgOp.getIteratorTypesArray());
+    rewriter.inlineRegionBefore(linalgOp.getRegion(), replacementOp.getRegion(),
+                                replacementOp.getRegion().begin());
+    rewriter.replaceOp(linalgOp, replacementOp.getResultTensors());
+
+    return success();
+  }
+};
+
 } // namespace
 
 void GenericOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {
   results.add<EraseIdentityLinalgOp<GenericOp>>(context);
+  results.add<ScalarizeSingleElementConstants>(context);
 }
 
 LogicalResult GenericOp::fold(FoldAdaptor, SmallVectorImpl<OpFoldResult> &) {


### PR DESCRIPTION
There are many other patterns and checks within Linalg that define a
scalar to be a single value that is not a single element tensor type.

This blocks certain transforms (LinalgSpecialization) and checks.

Take for example the following:
```
module {
  func.func public @main() -> tensor<32x256xf32> {
    %cst = arith.constant dense<0.58510226> : tensor<1xf32>
    %0 = tensor.empty() : tensor<32x256xf32>
    %1 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%cst : tensor<1xf32>) outs(%0 : tensor<32x256xf32>) {
    ^bb0(%in: f32, %out: f32):
      linalg.yield %in : f32
    } -> tensor<32x256xf32>
    func.return %1 : tensor<32x256xf32>
  }
}
```

The generic in question performs a broadcast from a scalar to a tensor.
However, the transforms and checks that identifies this oepration as a
FillOp do not trigger because the definition of a scalar at the input
is one that is not a RankedTensor, rather a single value.

The following change attempts to reconcile this discrepancy by
converting any known operand on a generic to a true scalar. Resulting
in the following:

```
module {
  func.func public @main() -> tensor<32x256xf32> {
    %cst = arith.constant 0.58510226 : f32
    %0 = tensor.empty() : tensor<32x256xf32>
    %1 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%cst : f32) outs(%0 : tensor<32x256xf32>) {
    ^bb0(%in: f32, %out: f32):
      linalg.yield %in : f32
    } -> tensor<32x256xf32>
    func.return %1 : tensor<32x256xf32>
  }
}
```